### PR TITLE
fix: remove redundant force-include causing build failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,6 @@ include = [
     "src/simple_resume/static/**/*",
     "src/simple_resume/palettes/**/*",
 ]
-force-include = { "src/simple_resume/templates/latex/basic.tex" = "simple_resume/templates/latex/basic.tex" }
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Fix build failure by removing redundant force-include configuration in pyproject.toml that was preventing the wheel from building successfully. The templates directory is already included via the standard include pattern, making the force-include unnecessary and problematic.