### PR TITLE
fix(packaging): fix gitignore interfering with wheel packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,10 +70,12 @@ palette-list = "simple_resume.palettes.cli:list"
 generate-random-palette-demo = "simple_resume.cli_random_palette_demo:main"
 
 [tool.hatch.build.targets.sdist]
-# Hatch doesn't include non Python files in subdirectories in source distributions by default,
-# so we force including the entire package and declare its src prefix.
-include = ["src/simple_resume"]
-sources = ["src"]
+include = ["src"]  # Only include content from src
+sources = ["src"]  # Map src/ to the root of the package
+
+[tool.hatch.build.targets.wheel]
+# wheel builder applies gitignore without the src/ prefix
+ignore-vcs = true
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Sorry for the noise but I found the root issue: the wheel builder applies `.gitignore` but after the `src` to root mapping. So even with the previous fix, `static` was included but not `templates`. This section was applied without negations:

```gitignore
*.pdf
*.html
*.tex
!src/simple_resume/templates/*.html
!src/simple_resume/templates/latex/*.tex
```

So html and tex files where excluded.

I also commented and reduced the sdist section.

