### PR TITLE
fix(packaging): add missing `jinja2` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "oyaml>=1.0,<2.0",
     "weasyprint>=62.1,<63.0",
     "palettable>=3.3.3,<4.0",
+    "jinja2>=3.0,<4.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2094,6 +2094,7 @@ name = "simple-resume"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "jinja2" },
     { name = "markdown" },
     { name = "oyaml" },
     { name = "palettable" },
@@ -2129,6 +2130,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "jinja2", specifier = ">=3.0,<4.0" },
     { name = "markdown", specifier = ">=3.7,<4.0" },
     { name = "mypy", marker = "extra == 'utils'", specifier = ">=1.11.0,<2.0" },
     { name = "oyaml", specifier = ">=1.0,<2.0" },


### PR DESCRIPTION
This PR add the missing `jinja2` dependency in `project.dependencies` making the project uninstallable from PyPI.
Test and local run are not failing because the dependency is present in `uv.lock` due to dev dependencies (transitive dependency of both `safety` and `pytypes`)