### PR TITLE
fix: harden path inference with root guard and strict validation

### DIFF
--- a/src/simple_resume/shell/generate/core.py
+++ b/src/simple_resume/shell/generate/core.py
@@ -12,7 +12,6 @@ For lazy-loaded versions with better startup performance, see `generate.lazy`.
 from __future__ import annotations
 
 import time
-import warnings
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -553,12 +552,10 @@ def _infer_data_dir_and_name(
     if data_dir is not None:
         base_dir = Path(data_dir)
         if base_dir.name.lower() == "input":
-            warnings.warn(
+            raise ValueError(
                 f"data_dir '{base_dir}' ends in 'input/'. Downstream path "
-                "resolution appends '/input' automatically, which may cause "
-                "path doubling. Consider passing the parent directory instead.",
-                UserWarning,
-                stacklevel=2,
+                "resolution appends '/input' automatically, which causes "
+                "path doubling. Pass the parent directory instead."
             )
         if source_path.exists() and source_path.is_dir():
             return source_path, None
@@ -572,7 +569,13 @@ def _infer_data_dir_and_name(
         if source_path.suffix.lower() in _YAML_SUFFIXES:
             parent = source_path.parent
             if parent.name.lower() == "input":
-                return parent.parent, source_path.stem
+                grandparent = parent.parent
+                if grandparent == Path("/") or grandparent == Path("."):
+                    raise ValueError(
+                        f"Cannot infer data_dir: '{source_path}' is in a root-level "
+                        "'input/' directory. Provide data_dir explicitly."
+                    )
+                return grandparent, source_path.stem
             return parent, source_path.stem
 
     raise ValueError(

--- a/tests/unit/shell/test_infer_data_dir.py
+++ b/tests/unit/shell/test_infer_data_dir.py
@@ -8,7 +8,6 @@ it.
 
 from __future__ import annotations
 
-import warnings
 from pathlib import Path
 
 import pytest
@@ -44,11 +43,12 @@ class TestInferDataDirFromYamlInInputDir:
         assert data_dir == tmp_path
         assert name == expected_stem
 
+    @pytest.mark.parametrize("dirname", ["input", "INPUT"])
     def test_yaml_in_nested_input_dir_returns_grandparent(
-        self, tmp_path: Path, story: Scenario
+        self, tmp_path: Path, story: Scenario, dirname: str
     ) -> None:
-        story.given("a YAML file inside a deeply nested input/ subdirectory")
-        nested = tmp_path / "projects" / "resumes" / "input"
+        story.given(f"a YAML file inside a deeply nested {dirname}/ subdirectory")
+        nested = tmp_path / "projects" / "resumes" / dirname
         nested.mkdir(parents=True)
         yaml_file = nested / "resume.yaml"
         yaml_file.touch()
@@ -56,7 +56,7 @@ class TestInferDataDirFromYamlInInputDir:
         story.when("inferring data_dir without an explicit override")
         data_dir, name = _infer_data_dir_and_name(yaml_file, data_dir=None)
 
-        story.then("data_dir points to the grandparent of input/")
+        story.then("data_dir points to the grandparent of the input/ directory")
         assert data_dir == tmp_path / "projects" / "resumes"
         assert name == "resume"
 
@@ -181,10 +181,10 @@ class TestInferDataDirWithExplicitOverride:
 
 
 class TestExplicitDataDirEndingInInput:
-    """Warn when explicit data_dir ends in ``input/`` (path-doubling risk)."""
+    """Raise ValueError when data_dir ends in ``input/`` (path-doubling)."""
 
     @pytest.mark.parametrize("dirname", ["input", "Input", "INPUT", "iNpUt"])
-    def test_warns_when_data_dir_named_input(
+    def test_raises_when_data_dir_named_input(
         self, tmp_path: Path, story: Scenario, dirname: str
     ) -> None:
         story.given(f"an explicit data_dir whose basename is '{dirname}'")
@@ -194,17 +194,11 @@ class TestExplicitDataDirEndingInInput:
         yaml_file.touch()
 
         story.when("inferring with that data_dir")
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            data_dir, name = _infer_data_dir_and_name(yaml_file, data_dir=input_dir)
+        story.then("a ValueError about path-doubling is raised regardless of case")
+        with pytest.raises(ValueError, match="path doubling"):
+            _infer_data_dir_and_name(yaml_file, data_dir=input_dir)
 
-        story.then("a UserWarning about path-doubling is emitted regardless of case")
-        assert len(caught) == 1
-        assert "path doubling" in str(caught[0].message).lower()
-        assert data_dir == input_dir
-        assert name == "sample"
-
-    def test_no_warning_for_normal_data_dir(
+    def test_no_error_for_normal_data_dir(
         self, tmp_path: Path, story: Scenario
     ) -> None:
         story.given("an explicit data_dir with a normal name")
@@ -214,12 +208,11 @@ class TestExplicitDataDirEndingInInput:
         yaml_file.touch()
 
         story.when("inferring with that data_dir")
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            _infer_data_dir_and_name(yaml_file, data_dir=custom_dir)
+        data_dir, name = _infer_data_dir_and_name(yaml_file, data_dir=custom_dir)
 
-        story.then("no warning is emitted")
-        assert len(caught) == 0
+        story.then("no error is raised and data_dir is used as-is")
+        assert data_dir == custom_dir
+        assert name == "sample"
 
 
 class TestRootLevelInputGuard:
@@ -250,6 +243,22 @@ class TestRootLevelInputGuard:
         story.then("ValueError is raised because file doesn't exist")
         with pytest.raises(ValueError, match="Unable to infer data_dir"):
             _infer_data_dir_and_name("/input/resume.yaml", data_dir=None)
+
+    def test_relative_input_dir_guard(
+        self, tmp_path: Path, story: Scenario, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        story.given("a YAML at relative input/resume.yaml (grandparent is '.')")
+        input_dir = tmp_path / "input"
+        input_dir.mkdir()
+        yaml_file = input_dir / "resume.yaml"
+        yaml_file.touch()
+
+        monkeypatch.chdir(tmp_path)
+
+        story.when("inferring data_dir via the relative path")
+        story.then("ValueError is raised because grandparent resolves to '.'")
+        with pytest.raises(ValueError, match="root-level"):
+            _infer_data_dir_and_name(Path("input/resume.yaml"), data_dir=None)
 
 
 class TestInferDataDirErrorCases:

--- a/tests/unit/shell/test_io_utils.py
+++ b/tests/unit/shell/test_io_utils.py
@@ -101,6 +101,7 @@ class TestResolvePathsForRead:
 
         result = resolve_paths_for_read(None, {}, candidate)
         assert result.data == tmp_path
+        assert result.input == input_dir
 
     def test_root_level_input_dir_raises(self) -> None:
         """Reject candidate in root-level input/ where grandparent is /."""


### PR DESCRIPTION
## Summary

- Add explicit root-level guard in `_infer_data_dir_and_name` to prevent `parent.parent` from yielding `/` or `.` (defense-in-depth, fixes #93)
- Replace `UserWarning` with `ValueError` for `data_dir` ending in `input/` — path doubling is always a bug, not recoverable (#94)
- Parametrize nested input dir test with `INPUT` variant and add `result.input` assertion in `test_io_utils` (#95)

Fixes #93, fixes #94, fixes #95

## Test plan

- [x] New test `test_relative_input_dir_guard` validates the root-level guard via relative path + chdir
- [x] Updated `TestExplicitDataDirEndingInInput` tests expect `ValueError` instead of `UserWarning`
- [x] Parametrized nested dir test covers both `input` and `INPUT` variants
- [x] All 1972 existing tests pass (no regressions)
- [x] All pre-commit hooks pass