### PR TITLE
feat(ats): add batch screening mode for multi-resume ranking

### DIFF
--- a/src/simple_resume/shell/cli/_screen.py
+++ b/src/simple_resume/shell/cli/_screen.py
@@ -25,70 +25,93 @@ _POOR_THRESHOLD = 35
 _PASSING_THRESHOLD = 0.5
 
 
+_RESUME_SUFFIXES = {".txt", ".md", ".yaml", ".yml", ".json"}
+
+
+def _build_tournament(scorers_selection: str) -> ATSTournament:
+    """Build a tournament with the selected scoring algorithms."""
+    if scorers_selection == ScorerSelection.TFIDF:
+        return ATSTournament(scorers=[TFIDFScorer(weight=1.0)])
+    if scorers_selection == ScorerSelection.JACCARD:
+        return ATSTournament(scorers=[JaccardScorer(weight=1.0)])
+    if scorers_selection == ScorerSelection.KEYWORD:
+        return ATSTournament(scorers=[KeywordScorer(weight=1.0)])
+    return ATSTournament()
+
+
+def _collect_resume_files(directory: Path) -> list[Path]:
+    """Collect readable resume files from a directory."""
+    return sorted(
+        p
+        for p in directory.iterdir()
+        if p.is_file() and p.suffix.lower() in _RESUME_SUFFIXES
+    )
+
+
+def _output_report(content: str, output_path: Path | None) -> None:
+    """Print or save a report."""
+    if output_path:
+        output_path = Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(content)
+        print(f"Report saved to: {output_path}")
+    else:
+        print(content)
+
+
 def handle_screen_command(args: argparse.Namespace) -> int:  # noqa: PLR0912
-    """Screen resume against job description using ATS scoring."""
+    """Screen resume(s) against job description using ATS scoring."""
     resume_path: Path = args.resume
     job_path: Path = args.job
     output_path: Path | None = getattr(args, "output", None)
     report_format: str = getattr(args, "format", "text")
     scorers_selection: str = getattr(args, "scorers", "all")
     verbose: bool = getattr(args, "verbose", False)
+    batch: bool = getattr(args, "batch", False)
+    top_n: int | None = getattr(args, "top", None)
 
     try:
-        # Read resume text
+        # Read job description
+        job_text = _read_file_text(job_path)
+        if not job_text.strip():
+            print(f"Error: Job description file is empty: {job_path}")
+            return 1
+
+        tournament = _build_tournament(scorers_selection)
+
+        # Batch mode: screen all resumes in a directory
+        if batch:
+            return _handle_batch(
+                resume_path,
+                job_path,
+                job_text,
+                tournament,
+                top_n,
+                output_path,
+            )
+
+        # Single mode: screen one resume
         resume_text = _read_file_text(resume_path)
         if not resume_text.strip():
             print(f"Error: Resume file is empty or could not be read: {resume_path}")
             return 1
 
-        # Read job description
-        job_text = _read_file_text(job_path)
-        if not job_text.strip():
-            msg = f"Error: Job description file is empty: {job_path}"
-            print(msg)
-            return 1
-
-        # Configure scorers based on selection
-        if scorers_selection == ScorerSelection.ALL:
-            tournament = ATSTournament()  # Uses default scorers
-        elif scorers_selection == ScorerSelection.TFIDF:
-            tournament = ATSTournament(scorers=[TFIDFScorer(weight=1.0)])
-        elif scorers_selection == ScorerSelection.JACCARD:
-            tournament = ATSTournament(scorers=[JaccardScorer(weight=1.0)])
-        elif scorers_selection == ScorerSelection.KEYWORD:
-            tournament = ATSTournament(scorers=[KeywordScorer(weight=1.0)])
-        else:
-            tournament = ATSTournament()
-
-        # Run tournament
         result = tournament.score(resume_text, job_text)
 
-        # Generate report
         generator = ATSReportGenerator(
             result,
             resume_file=str(resume_path),
             job_file=str(job_path),
         )
 
-        # Output based on format
         if report_format == "yaml":
             report_content = generator.generate_yaml()
         elif report_format == "json":
             report_content = generator.generate_json()
-        else:  # text format
+        else:
             report_content = _format_text_report(result, verbose)
 
-        # Save or print
-        if output_path:
-            output_path = Path(output_path)
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            output_path.write_text(report_content)
-            print(f"Report saved to: {output_path}")
-        else:
-            print(report_content)
-
-        # Return exit code based on score
-        # Score 50+/100 is considered passing
+        _output_report(report_content, output_path)
         return 0 if result.overall_score >= _PASSING_THRESHOLD else 1
 
     except SimpleResumeError as exc:
@@ -96,6 +119,52 @@ def handle_screen_command(args: argparse.Namespace) -> int:  # noqa: PLR0912
         return 1
     except Exception as exc:  # pragma: no cover - safety net
         return _handle_unexpected_error(exc, "ATS screening")
+
+
+def _handle_batch(  # noqa: PLR0913
+    resume_path: Path,
+    job_path: Path,
+    job_text: str,
+    tournament: ATSTournament,
+    top_n: int | None,
+    output_path: Path | None,
+) -> int:
+    """Screen all resumes in a directory against a job description."""
+    if not resume_path.exists() or not resume_path.is_dir():
+        print(f"Error: '{resume_path}' is not a directory.")
+        return 1
+
+    resume_files = _collect_resume_files(resume_path)
+    if not resume_files:
+        print(
+            f"Error: No resume files found in '{resume_path}'. "
+            f"Supported: {', '.join(sorted(_RESUME_SUFFIXES))}"
+        )
+        return 1
+
+    # Score each resume
+    results: list[tuple[str, float]] = []
+    for rfile in resume_files:
+        text = _read_file_text(rfile)
+        if not text.strip():
+            continue
+        score = tournament.score(text, job_text).overall_score
+        results.append((rfile.name, score))
+
+    if not results:
+        print("Error: No resume files could be read.")
+        return 1
+
+    # Sort by score descending
+    results.sort(key=lambda x: x[1], reverse=True)
+
+    # Apply top-N limit
+    if top_n is not None and top_n > 0:
+        results = results[:top_n]
+
+    report = _format_batch_report(results, str(job_path))
+    _output_report(report, output_path)
+    return 0
 
 
 def _read_file_text(file_path: Path) -> str:
@@ -244,6 +313,32 @@ def _format_text_report(result: TournamentResult, verbose: bool = False) -> str:
         ]
     )
 
+    return "\n".join(lines)
+
+
+def _format_batch_report(results: list[tuple[str, float]], job_file: str) -> str:
+    """Format batch screening results as a ranked report."""
+    results = sorted(results, key=lambda x: x[1], reverse=True)
+    lines = [
+        "=" * 60,
+        "BATCH ATS SCREENING REPORT",
+        "=" * 60,
+        "",
+        f"Job description: {job_file}",
+        f"Resumes scored:  {len(results)}",
+        "",
+        "-" * 60,
+        "RANKED RESULTS",
+        "-" * 60,
+        "",
+    ]
+
+    for rank, (name, score) in enumerate(results, 1):
+        score_100 = score * 100
+        status = _get_status_label(score_100)
+        lines.append(f"{rank}. {name:40s} {score_100:5.1f}/100  {status}")
+
+    lines.extend(["", "=" * 60])
     return "\n".join(lines)
 
 

--- a/src/simple_resume/shell/cli/main.py
+++ b/src/simple_resume/shell/cli/main.py
@@ -41,6 +41,7 @@ from simple_resume.shell.cli._import import (  # noqa: F401
 )
 from simple_resume.shell.cli._screen import (  # noqa: F401
     _collect_ats_warnings,
+    _format_batch_report,
     _format_text_report,
     _get_status_label,
     _read_file_text,
@@ -290,6 +291,17 @@ def create_parser() -> argparse.ArgumentParser:
         "-v",
         action="store_true",
         help="Show detailed breakdown of scores",
+    )
+    screen_parser.add_argument(
+        "--batch",
+        action="store_true",
+        help="Batch mode: treat resume arg as a directory of resumes",
+    )
+    screen_parser.add_argument(
+        "--top",
+        type=int,
+        default=None,
+        help="Show only the top N results (batch mode only)",
     )
 
     # import subcommand

--- a/tests/unit/test_cli_screen_batch.py
+++ b/tests/unit/test_cli_screen_batch.py
@@ -1,0 +1,165 @@
+"""Tests for batch screening CLI feature (issue #7).
+
+Covers batch mode: screening multiple resumes against a single job
+description, ranking them, and returning top-N results.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from simple_resume.shell.cli._screen import (
+    _format_batch_report,
+    handle_screen_command,
+)
+from tests.bdd import Scenario
+
+
+def _make_args(**kwargs):  # type: ignore[no-untyped-def]
+    """Build a minimal argparse.Namespace-like object."""
+
+    class Args:
+        pass
+
+    args = Args()
+    defaults = {
+        "resume": None,
+        "job": None,
+        "output": None,
+        "format": "text",
+        "scorers": "all",
+        "verbose": False,
+        "batch": False,
+        "top": None,
+    }
+    defaults.update(kwargs)
+    for k, v in defaults.items():
+        setattr(args, k, v)
+    return args
+
+
+class TestBatchScreeningCLI:
+    """Batch screening: multiple resumes vs. one job description."""
+
+    def test_batch_mode_scores_all_resumes_in_directory(
+        self, tmp_path: Path, story: Scenario, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        story.given("a directory with 3 resume files and a job description")
+        resumes_dir = tmp_path / "resumes"
+        resumes_dir.mkdir()
+        skills = ["Python developer", "Java developer", "Go developer"]
+        for i, skill in enumerate(skills):
+            (resumes_dir / f"resume_{i}.txt").write_text(
+                f"Experienced {skill} with 5 years of experience."
+            )
+        job_file = tmp_path / "job.txt"
+        job_file.write_text("Looking for a Python developer with experience.")
+
+        story.when("running batch screen")
+        args = _make_args(resume=resumes_dir, job=job_file, batch=True)
+        exit_code = handle_screen_command(args)
+
+        story.then("all resumes are scored and a ranked report is printed")
+        output = capsys.readouterr().out
+        assert exit_code == 0
+        assert "BATCH" in output.upper()
+        assert "resume_0" in output
+        assert "resume_1" in output
+        assert "resume_2" in output
+
+    def test_batch_mode_top_n_limits_results(
+        self, tmp_path: Path, story: Scenario, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        story.given("a directory with 5 resumes and --top 2")
+        resumes_dir = tmp_path / "resumes"
+        resumes_dir.mkdir()
+        for i in range(5):
+            (resumes_dir / f"resume_{i}.txt").write_text(
+                f"Engineer #{i} skilled in Python and data pipelines."
+            )
+        job_file = tmp_path / "job.txt"
+        job_file.write_text("Python data engineer needed.")
+
+        story.when("running batch screen with top=2")
+        args = _make_args(resume=resumes_dir, job=job_file, batch=True, top=2)
+        exit_code = handle_screen_command(args)
+
+        story.then("only 2 results are shown")
+        output = capsys.readouterr().out
+        assert exit_code == 0
+        # Count ranked entries (lines with "resume_" in ranked output)
+        ranked_lines = [
+            line
+            for line in output.splitlines()
+            if line.strip().startswith(("1.", "2.", "3.", "4.", "5."))
+        ]
+        assert len(ranked_lines) == 2
+
+    def test_batch_mode_empty_directory_returns_error(
+        self, tmp_path: Path, story: Scenario, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        story.given("an empty directory")
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        job_file = tmp_path / "job.txt"
+        job_file.write_text("Python developer needed.")
+
+        story.when("running batch screen on empty directory")
+        args = _make_args(resume=empty_dir, job=job_file, batch=True)
+        exit_code = handle_screen_command(args)
+
+        story.then("an error is returned")
+        output = capsys.readouterr().out
+        assert exit_code == 1
+        assert "no resume" in output.lower()
+
+    def test_batch_mode_nonexistent_directory_returns_error(
+        self, tmp_path: Path, story: Scenario
+    ) -> None:
+        story.given("a non-existent directory")
+        missing = tmp_path / "missing"
+        job_file = tmp_path / "job.txt"
+        job_file.write_text("Python developer needed.")
+
+        story.when("running batch screen on missing directory")
+        args = _make_args(resume=missing, job=job_file, batch=True)
+        exit_code = handle_screen_command(args)
+
+        story.then("an error is returned")
+        assert exit_code == 1
+
+
+class TestBatchReportFormatting:
+    """Batch report output formatting."""
+
+    def test_format_batch_report_ranks_by_score(self, story: Scenario) -> None:
+        story.given("batch results with varying scores")
+        results = [
+            ("resume_c.txt", 0.9),
+            ("resume_a.txt", 0.5),
+            ("resume_b.txt", 0.7),
+        ]
+
+        story.when("formatting the batch report")
+        report = _format_batch_report(results, "job.txt")
+
+        story.then("results are sorted by score descending")
+        lines = report.splitlines()
+        ranked = [ln for ln in lines if ln.strip().startswith(("1.", "2.", "3."))]
+        assert len(ranked) == 3
+        assert "resume_c" in ranked[0]
+        assert "resume_b" in ranked[1]
+        assert "resume_a" in ranked[2]
+
+    def test_format_batch_report_includes_header(self, story: Scenario) -> None:
+        story.given("batch results")
+        results = [("resume.txt", 0.75)]
+
+        story.when("formatting the batch report")
+        report = _format_batch_report(results, "job.txt")
+
+        story.then("the report includes a header")
+        assert "BATCH" in report.upper()
+        assert "job.txt" in report


### PR DESCRIPTION
## Summary

- Add `--batch` and `--top` flags to the `sr screen` CLI command
- When `--batch` is passed, the resume argument is treated as a directory; all readable files are scored against the job description
- Results are ranked by score descending and displayed in a tabular report
- `--top N` limits output to the top N candidates

Example usage:
```bash
sr screen resumes/ job.txt --batch --top 5
```

The core infrastructure (ATSTournament, multi-algorithm scoring, gap analysis) was already in place. This adds the CLI batch surface and report formatting.

Fixes #7

## Test plan

- [x] `test_batch_mode_scores_all_resumes_in_directory` — scores 3 resumes, verifies ranked output
- [x] `test_batch_mode_top_n_limits_results` — verifies `--top 2` shows only 2 results
- [x] `test_batch_mode_empty_directory_returns_error` — empty dir returns exit code 1
- [x] `test_batch_mode_nonexistent_directory_returns_error` — missing dir returns exit code 1
- [x] `test_format_batch_report_ranks_by_score` — verifies descending sort
- [x] `test_format_batch_report_includes_header` — verifies report header
- [x] All 1976 tests pass (6 new + 1970 existing)
- [x] All pre-commit hooks pass