### PR TITLE
feat(ats): diversify sample YAML descriptions with unique personas

### DIFF
--- a/sample/input/sample_1.yaml
+++ b/sample/input/sample_1.yaml
@@ -1,6 +1,6 @@
 template: resume_no_bars
 
-full_name: John Doe
+full_name: Priya Raghavan
 
 # Address should be a list (with only one element if needed)
 address:
@@ -24,27 +24,27 @@ titles:
   keyskills: Key Skills
 
 description: |
-  Results-driven **Software Engineer** with 5+ years building scalable data pipelines and cloud-native applications. Proficient in **Python**, **JavaScript**, and **SQL** with hands-on experience deploying **microservices** on **AWS** and **Docker/Kubernetes**. Strong communicator passionate about **CI/CD** best practices and **REST API** design.
+  **Backend Engineer** with 6+ years designing high-throughput **data pipelines** and event-driven systems. Skilled in **Python**, **Go**, and **PostgreSQL** with deep experience building **streaming architectures** using **Apache Kafka** and **Redis**. Committed to **observability**, **performance tuning**, and shipping reliable distributed services.
 
 expertise:
-  - Software Engineering
-  - Data Engineering
-  - Cloud Platforms (AWS)
-  - Microservices Architecture
+  - Backend Systems Design
+  - Data Pipeline Architecture
+  - Streaming & Event Processing
+  - Performance Engineering
 
 certification:
   - AWS Certified Solutions Architect
-  - Docker Certified Associate
+  - Confluent Certified Developer for Apache Kafka
 
 keyskills:
   - Python
-  - JavaScript
-  - React
-  - SQL / PostgreSQL
-  - AWS / Docker / Kubernetes
-  - REST APIs
-  - CI/CD / Git
-  - Microservices
+  - Go
+  - PostgreSQL / Redis
+  - Apache Kafka
+  - Docker / Kubernetes
+  - gRPC / REST APIs
+  - Observability (Datadog)
+  - Linux / Shell Scripting
 
 body:
   Experience:

--- a/sample/input/sample_2.yaml
+++ b/sample/input/sample_2.yaml
@@ -1,6 +1,6 @@
 template: resume_no_bars
 
-full_name: John Doe
+full_name: Marcus Jennings
 
 # Address should be a list (with only one element if needed)
 address:
@@ -22,26 +22,26 @@ titles:
   keyskills: Key Skills
 
 description: |
-  Full-stack **Software Engineer** specializing in **Python** and **JavaScript/React** development. Experienced building **REST APIs** and deploying **microservices** on **AWS** with **Docker** and **Kubernetes**. Strong background in **SQL/PostgreSQL** databases and **CI/CD** pipelines using **Git**.
+  **DevOps/SRE Engineer** with 7+ years automating infrastructure and improving system reliability at scale. Expert in **Terraform**, **Ansible**, and **Kubernetes** orchestration across **AWS** and **GCP** environments. Passionate about **incident response**, **SLO-driven development**, and building **self-healing** production systems.
 
 expertise:
-  - Software Engineering
-  - Full-Stack Development
-  - Cloud Platforms (AWS)
-  - Microservices Architecture
+  - Site Reliability Engineering
+  - Infrastructure as Code
+  - Cloud Platform Operations
+  - Incident Management & Response
 
 certification:
-  - AWS Certified Developer
-  - Kubernetes Administrator (CKA)
+  - AWS Certified DevOps Engineer Professional
+  - Certified Kubernetes Administrator (CKA)
 
 keyskills:
-  - Python
-  - JavaScript / React
-  - SQL / PostgreSQL
-  - AWS / Docker / Kubernetes
-  - REST APIs
-  - CI/CD / Git
-  - Microservices
+  - Terraform / Ansible
+  - Kubernetes / Helm
+  - AWS / GCP
+  - Python / Bash
+  - Prometheus / Grafana
+  - CI/CD (GitHub Actions, Jenkins)
+  - Linux Administration
 
 body:
   Experience:

--- a/sample/input/sample_contrast_demo.yaml
+++ b/sample/input/sample_contrast_demo.yaml
@@ -1,7 +1,7 @@
 template: resume_with_bars
 
-full_name: Casey Contrast
-job_title: Color Contrast Specialist
+full_name: Amara Osei
+job_title: UX / Accessibility Engineer
 
 address:
   - 101 Spectrum Way
@@ -20,31 +20,31 @@ titles:
   languages: Languages
 
 description: |
-  **Software Engineer** focused on accessibility and frontend development. Expert in **JavaScript/React** with strong **Python** backend skills. Deploys applications using **Docker** on **AWS** with **PostgreSQL** databases. Advocates for **CI/CD** and **REST API** best practices.
+  **UX/Accessibility Engineer** dedicated to building inclusive digital experiences that meet **WCAG 2.2 AAA** standards. Fluent in **TypeScript**, **React**, and **ARIA** patterns with a strong foundation in **automated accessibility testing** and **assistive technology** integration. Bridges design and engineering to ensure every user can navigate, understand, and interact with products.
 
 skills:
-  JavaScript/React: 55
-  Python: 48
-  AWS/Docker: 52
-  SQL/PostgreSQL: 45
-  CI/CD: 40
+  Accessibility/WCAG: 58
+  TypeScript/React: 55
+  ARIA Patterns: 50
+  Assistive Tech: 47
+  Design Systems: 44
 
 expertise:
-  - Frontend Development (React)
-  - Accessibility Engineering
-  - Cloud Platforms (AWS)
+  - WCAG Compliance & Auditing
+  - Inclusive Design Systems
+  - Assistive Technology Testing
 
 certification:
-  - AWS Certified Developer
-  - Certified Professional in Accessibility
+  - IAAP Certified Professional in Accessibility (CPAC)
+  - W3C Web Accessibility Specialist
 
 keyskills:
-  - JavaScript / React
-  - Python
-  - AWS / Docker / Kubernetes
-  - SQL / PostgreSQL
-  - REST APIs / Git
-  - Microservices / CI/CD
+  - TypeScript / React
+  - WCAG 2.2 / ARIA
+  - Axe / Lighthouse / Pa11y
+  - Figma / Storybook
+  - Screen Reader Testing
+  - Inclusive Design Patterns
 
 languages:
   English: 60

--- a/sample/input/sample_dark_sidebar.yaml
+++ b/sample/input/sample_dark_sidebar.yaml
@@ -1,7 +1,7 @@
 template: resume_with_bars
 
-full_name: Casey Dark Mode
-job_title: Design Technologist
+full_name: Soren Lindqvist
+job_title: Cybersecurity Analyst
 
 address:
   - 101 Dark Way
@@ -20,31 +20,31 @@ titles:
   languages: Languages
 
 description: |
-  **Software Engineer** with expertise in **JavaScript/React** and **Python** development. Builds scalable **microservices** deployed on **AWS** with **Docker** and **Kubernetes**. Strong experience with **SQL/PostgreSQL** databases and **REST APIs**. Passionate about **CI/CD** and modern **Git** workflows.
+  **Cybersecurity Analyst** with 5+ years defending enterprise networks through **threat hunting**, **SIEM** operations, and **incident response**. Proficient in **Python** scripting for security automation and experienced with **vulnerability assessment** tools including **Nessus** and **Burp Suite**. Holds active **CISSP** and **CEH** certifications.
 
 skills:
-  JavaScript/React: 50
-  Python: 48
-  AWS/Docker: 52
-  SQL/PostgreSQL: 45
-  CI/CD/Git: 40
+  Threat Detection: 55
+  Incident Response: 52
+  SIEM / Log Analysis: 50
+  Vulnerability Assessment: 48
+  Python Scripting: 45
 
 expertise:
-  - Frontend Development (React)
-  - Backend Engineering (Python)
-  - Cloud Platforms (AWS)
+  - Threat Hunting & Intelligence
+  - Security Operations (SOC)
+  - Cloud Security (AWS/Azure)
 
 certification:
-  - AWS Certified Solutions Architect
-  - Docker Certified Associate
+  - CISSP (Certified Information Systems Security Professional)
+  - CEH (Certified Ethical Hacker)
 
 keyskills:
-  - JavaScript / React
-  - Python
-  - AWS / Docker / Kubernetes
-  - SQL / PostgreSQL
-  - REST APIs
-  - Microservices / CI/CD / Git
+  - Python / Bash
+  - Splunk / Elastic SIEM
+  - Nessus / Burp Suite
+  - MITRE ATT&CK Framework
+  - AWS Security / IAM
+  - Incident Response & Forensics
 
 languages:
   English: 58

--- a/sample/input/sample_latex.yaml
+++ b/sample/input/sample_latex.yaml
@@ -1,7 +1,7 @@
 template: resume_no_bars
 
-full_name: Avery Candidate
-job_title: Software Engineer
+full_name: Dr. Elena Vasquez
+job_title: Data Scientist / ML Engineer
 
 address:
   - 123 Example Road
@@ -21,38 +21,38 @@ titles:
   keyskills: Key Skills
 
 description: |
-  Results-driven **Software Engineer** with expertise in **Python**, **Go**, and cloud-native development. Built scalable **microservices** on **AWS** using **Docker** and **Kubernetes**. Strong background in **SQL/PostgreSQL**, **REST APIs**, and **CI/CD** pipelines with **Git**. Excellent communication skills.
+  **Data Scientist** and **ML Engineer** with a Ph.D. in computational statistics and 8+ years applying **machine learning** to real-world problems. Expert in **PyTorch**, **scikit-learn**, and **TensorFlow** with production experience deploying models via **MLflow** and **Kubeflow**. Published researcher in **NLP** and **Bayesian inference** with strong **R** and **Python** fluency.
 
 expertise:
-  Platform Engineering:
-    - Distributed systems
-    - Observability
-    - Incident response
-  Data Platforms:
-    - Streaming pipelines
-    - Analytics engineering
+  Machine Learning:
+    - Deep learning (CNNs, transformers)
+    - NLP & text analytics
+    - Bayesian modeling
+  Data Engineering:
+    - Feature stores
+    - ML pipeline orchestration
 
 programming:
   Languages:
     - Python
-    - Go
-    - Rust
+    - R
+    - Julia
   Tooling:
-    - Terraform
-    - Airflow
-    - dbt
+    - PyTorch / TensorFlow
+    - MLflow / Kubeflow
+    - Spark / dbt
 
 keyskills:
-  - Python / JavaScript / React
-  - AWS / Docker / Kubernetes
-  - SQL / PostgreSQL
-  - REST APIs / Microservices
-  - CI/CD / Git
-  - Cross-team communication
+  - Python / R / Julia
+  - PyTorch / TensorFlow / scikit-learn
+  - MLflow / Kubeflow
+  - SQL / Spark / dbt
+  - NLP / Computer Vision
+  - Statistical Modeling & Experimentation
 
 certification:
-  - AWS Certified Solutions Architect
-  - Google Professional Cloud Architect
+  - Google Professional Machine Learning Engineer
+  - AWS Certified Machine Learning Specialty
 
 body:
   Experience:

--- a/sample/input/sample_multipage_demo.yaml
+++ b/sample/input/sample_multipage_demo.yaml
@@ -1,6 +1,6 @@
 template: resume_with_bars
 
-full_name: Jordan Multipage
+full_name: Kenji Nakamura
 job_title: Principal Solutions Architect
 
 address:
@@ -26,7 +26,7 @@ titles:
   languages: Languages
 
 description: |
-  **Software Engineer** and Principal Solutions Architect with 15+ years building scalable cloud platforms. Expert in **Python**, **JavaScript/React**, and **Go** with deep experience deploying **microservices** on **AWS** using **Docker** and **Kubernetes**. Strong background in **SQL/PostgreSQL**, **REST APIs**, and **CI/CD** pipelines. Excellent communication and leadership skills.
+  **Principal Solutions Architect** bridging business strategy and technical execution across enterprise-scale platforms. 15+ years leading **cloud migrations**, **multi-region deployments**, and **platform modernization** programs. Adept at translating complex requirements into pragmatic architectures using **Go**, **Terraform**, and **Kubernetes** while mentoring engineering teams and driving **FinOps** disciplines.
 
 skills:
   Cloud Architecture: 55
@@ -93,12 +93,12 @@ programming:
     - PowerShell
 
 keyskills:
-  - Python / JavaScript / React
-  - AWS / Docker / Kubernetes
-  - SQL / PostgreSQL
-  - REST APIs / Microservices
-  - CI/CD / Git
-  - Strong communication skills
+  - Go / Python / TypeScript
+  - AWS / GCP / Multi-Cloud
+  - Terraform / Kubernetes / Helm
+  - Platform Strategy & FinOps
+  - Architecture Decision Records
+  - Executive Stakeholder Communication
 
 languages:
   English: 60

--- a/sample/input/sample_palette_demo.yaml
+++ b/sample/input/sample_palette_demo.yaml
@@ -1,7 +1,7 @@
 template: resume_with_bars
 
-full_name: Casey Palette
-job_title: Product Design Technologist
+full_name: Daniela Ferreira
+job_title: Mobile App Developer
 
 address:
   - 101 Color Way
@@ -23,50 +23,50 @@ titles:
   languages: Languages
 
 description: |
-  **Software Engineer** specializing in **JavaScript/React** and **Python** development. Builds scalable **microservices** on **AWS** with **Docker** and **Kubernetes**. Strong experience with **SQL/PostgreSQL** databases and **REST APIs**. Passionate about **CI/CD** and modern **Git** workflows. Excellent communication skills.
+  **Mobile App Developer** with 6+ years shipping consumer-facing **iOS** and **Android** applications using **Swift**, **Kotlin**, and **React Native**. Experienced in **offline-first** architectures, **push notification** systems, and **App Store optimization**. Driven by crafting performant, accessible mobile experiences backed by **analytics** and **A/B testing**.
 
 skills:
-  UI/UX Design: 55
-  Frontend Development: 48
-  Design Systems: 52
-  Prototyping: 46
-  User Research: 42
-  Data Visualization: 38
+  iOS (Swift/SwiftUI): 56
+  Android (Kotlin): 50
+  React Native: 48
+  Mobile CI/CD: 45
+  App Store Optimization: 40
+  Analytics & A/B Testing: 38
 
 expertise:
-  Product Strategy:
-    - Journey mapping
-    - Experiment design
-  Delivery:
-    - Design systems
-    - Rapid prototyping
-  Research & Analytics:
-    - Field studies
-    - Accessibility audits
+  Native Development:
+    - Swift / SwiftUI
+    - Kotlin / Jetpack Compose
+  Cross-Platform:
+    - React Native
+    - Expo
+  Quality & Release:
+    - Fastlane / Bitrise
+    - Crashlytics / Sentry
 
 certification:
-  - DesignOps Professional
-  - Accessibility Auditor
-  - ScrumMaster (PSM I)
+  - Apple Certified iOS Developer
+  - Google Associate Android Developer
+  - AWS Certified Cloud Practitioner
 
 programming:
-  Prototyping:
+  Mobile:
+    - Swift
+    - Kotlin
+  Cross-Platform:
     - TypeScript
-    - React
-  Data & Automation:
+    - React Native
+  Backend:
     - Python
-    - SQL
-  Infrastructure:
-    - Terraform
-    - Docker
+    - Firebase
 
 keyskills:
-  - JavaScript / React
-  - Python
-  - AWS / Docker / Kubernetes
-  - SQL / PostgreSQL
-  - REST APIs / Microservices
-  - CI/CD / Git
+  - Swift / Kotlin
+  - React Native / Expo
+  - Firebase / Supabase
+  - Fastlane / Bitrise
+  - App Store Connect / Google Play
+  - Analytics / A/B Testing
 
 languages:
   English: 60

--- a/sample/input/sample_palette_demo_random.yaml
+++ b/sample/input/sample_palette_demo_random.yaml
@@ -1,6 +1,6 @@
 template: resume_with_bars
-full_name: Taylor Lee
-job_title: DevOps Engineer
+full_name: Nia Whitfield
+job_title: Cloud Infrastructure Engineer
 address:
 - 101 Color Way
 - Austin, TX
@@ -18,45 +18,46 @@ titles:
   keyskills: Key Skills
   languages: Languages
 description: |
-  **Software Engineer** with expertise in **Python**, **JavaScript/React**, and cloud-native development. Builds scalable **microservices** on **AWS** using **Docker** and **Kubernetes**. Strong experience with **SQL/PostgreSQL** databases, **REST APIs**, and **CI/CD** pipelines using **Git**. Excellent communication skills.
+  **Cloud Infrastructure Engineer** specializing in designing and operating **multi-cloud** environments across **AWS**, **GCP**, and **Azure**. Expert in **Terraform**, **Pulumi**, and **Kubernetes** with 8+ years building **self-service platforms** and **cost-optimized** architectures. Strong advocate for **infrastructure as code**, **GitOps** workflows, and **zero-trust** networking.
 skills:
-  UI/UX Design: 55
-  Frontend Development: 48
-  Design Systems: 52
-  Prototyping: 46
-  User Research: 42
-  Data Visualization: 38
+  Cloud Architecture: 56
+  Infrastructure as Code: 54
+  Kubernetes / Containers: 52
+  Networking / Security: 48
+  Cost Optimization: 44
+  Observability: 42
 expertise:
-  Product Strategy:
-  - Journey mapping
-  - Experiment design
-  Delivery:
-  - Design systems
-  - Rapid prototyping
-  Research & Analytics:
-  - Field studies
-  - Accessibility audits
-certification:
-- DesignOps Professional
-- Accessibility Auditor
-- ScrumMaster (PSM I)
-programming:
-  Prototyping:
-  - TypeScript
-  - React
-  Data & Automation:
-  - Python
-  - SQL
+  Cloud Platforms:
+  - AWS (EKS, Lambda, CloudFormation)
+  - GCP (GKE, Cloud Run)
   Infrastructure:
-  - Terraform
-  - Docker
-keyskills:
+  - Terraform / Pulumi
+  - GitOps (ArgoCD, Flux)
+  Reliability:
+  - Chaos engineering
+  - Capacity planning
+certification:
+- AWS Solutions Architect Professional
+- Google Cloud Professional Cloud Architect
+- HashiCorp Terraform Associate
+programming:
+  Languages:
+  - Go
   - Python
-  - JavaScript / React
-  - AWS / Docker / Kubernetes
-  - SQL / PostgreSQL
-  - REST APIs / Microservices
-  - CI/CD / Git
+  - Bash
+  IaC & Orchestration:
+  - Terraform / Pulumi
+  - Helm / Kustomize
+  Observability:
+  - Prometheus
+  - Grafana
+keyskills:
+  - Terraform / Pulumi
+  - AWS / GCP / Azure
+  - Kubernetes / Helm / ArgoCD
+  - Go / Python / Bash
+  - Networking / Zero-Trust
+  - FinOps / Cost Optimization
 languages:
   English: 60
   Spanish: 35


### PR DESCRIPTION
## Summary

Each of the 8 `sample_*.yaml` files now represents a distinct profession instead of nearly identical "Software Engineer" descriptions:

| File | New Name | Persona |
|------|----------|---------|
| `sample_1.yaml` | Priya Raghavan | Backend Engineer (data pipelines, Go, Kafka) |
| `sample_2.yaml` | Marcus Jennings | DevOps/SRE Engineer (Terraform, Ansible, K8s) |
| `sample_multipage_demo.yaml` | Kenji Nakamura | Principal Solutions Architect (cloud, FinOps) |
| `sample_contrast_demo.yaml` | Amara Osei | UX/Accessibility Engineer (WCAG, ARIA) |
| `sample_dark_sidebar.yaml` | Soren Lindqvist | Cybersecurity Analyst (threat hunting, SIEM) |
| `sample_latex.yaml` | Dr. Elena Vasquez | Data Scientist / ML Engineer (PyTorch, NLP) |
| `sample_palette_demo.yaml` | Daniela Ferreira | Mobile App Developer (Swift, Kotlin) |
| `sample_palette_demo_random.yaml` | Nia Whitfield | Cloud Infrastructure Engineer (Terraform) |

Updated fields: `full_name`, `job_title`, `description`, and sidebar skills. All `body:`, `config:`, and `template:` sections left untouched.

Fixes #83

## Test plan

- [x] All descriptions use `**bold**` markdown for ATS-friendly keyword highlighting
- [x] Template and config sections unchanged (rendering unaffected)
- [x] All pre-commit hooks pass